### PR TITLE
adjustment the pivot of the tile to (0.5, 0, 0.5)

### DIFF
--- a/Editor/Utility/TilemapCursor.cs
+++ b/Editor/Utility/TilemapCursor.cs
@@ -208,7 +208,7 @@ namespace TilemapCreator3D.EditorOnly {
                         for(int z = 0; z < _area.Depth; z++) {
                             for(int y = 0; y < _area.Height; y++) {
                                 for(int x = 0; x < _area.Width; x++) {
-                                    float3 wPos = _map.GridToWorld(_area.Min + new int3(x, y, z), new float3(0.5f, 0.5f, 0.5f)) + toCamOffset;
+                                    float3 wPos = _map.GridToWorld(_area.Min + new int3(x, y, z), new float3(0.5f, 0.0f, 0.5f)) + toCamOffset;
                                     Graphics.DrawMeshNow(previewMesh, Matrix4x4.TRS(wPos, trs.rotation * Quaternion.Euler(0, _settings.Rotation * 90, 0), trs.lossyScale));
                                 }
                             }

--- a/Runtime/Behaviour/TilemapMesh.cs
+++ b/Runtime/Behaviour/TilemapMesh.cs
@@ -153,7 +153,7 @@ namespace TilemapCreator3D {
                         if(bTile == null || info.Mesh == null || bTile.Material == null) continue;
 
                         // Transform
-                        float3 position = new float3(x - area.Min.x + 0.5f, y - area.Min.y + 0.5f, z - area.Min.z + 0.5f) * gridSize;
+                        float3 position = new float3(x - area.Min.x + 0.5f, y - area.Min.y, z - area.Min.z + 0.5f) * gridSize;
                         Quaternion rotation = tile.GetRotation();
                         float3 scale = 1.0f;
 


### PR DESCRIPTION
Currently, commonly used grid tools all use the center of the bottom surface of an tile rather than the centroid position of the object. I have adjusted the centroid specifications of the tile and its phantom to (0.5, 0, 0.5).